### PR TITLE
Added Domain Field in create and edit for job

### DIFF
--- a/Modules/HR/Config/config.php
+++ b/Modules/HR/Config/config.php
@@ -26,6 +26,12 @@ return [
         'closed' => 'Closed'
     ],
 
+    'domain-status' => [
+        'engineering' => 'Engineering',
+        'design' => 'Design',
+        'marketing' => 'Marketing'
+    ],
+
     'template-variables' => [
         'applicant-name' => '|*applicant_name*|',
         'interview-time' => '|*interview_time*|',

--- a/Modules/HR/Config/config.php
+++ b/Modules/HR/Config/config.php
@@ -18,18 +18,18 @@ return [
             'title' => 'Volunteer',
             'type' => 'volunteer',
         ],
+        'domains' => [
+            'engineering' => 'Engineering',
+            'design' => 'Design',
+            'marketing' => 'Marketing'
+        ],
+    
     ],
 
     'opportunities-status' => [
         'draft' => 'Draft',
         'published' => 'Published',
         'closed' => 'Closed'
-    ],
-
-    'domain-status' => [
-        'engineering' => 'Engineering',
-        'design' => 'Design',
-        'marketing' => 'Marketing'
     ],
 
     'template-variables' => [

--- a/Modules/HR/Entities/Job.php
+++ b/Modules/HR/Entities/Job.php
@@ -13,7 +13,7 @@ class Job extends Model
 {
     use SoftDeletes;
 
-    protected $fillable = ['title', 'type', 'description', 'posted_by', 'link', 'status', 'facebook_post', 'instagram_post', 'twitter_post', 'linkedin_post'];
+    protected $fillable = ['title', 'type', 'domain', 'description', 'posted_by', 'link', 'status', 'facebook_post', 'instagram_post', 'twitter_post', 'linkedin_post'];
 
     protected $table = 'hr_jobs';
 

--- a/Modules/HR/Http/Controllers/Recruitment/JobController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/JobController.php
@@ -69,6 +69,7 @@ class JobController extends Controller
 
         $opportunity = Job::create([
             'title' => $validated['title'],
+            'domain' => $validated['domain'],
             'description' => $validated['description'] ?? null, // null needed for backward compatibility
             'type' => $validated['type'],
             'posted_by' => $validated['by'] ?? null,

--- a/Modules/HR/Http/Requests/Recruitment/JobRequest.php
+++ b/Modules/HR/Http/Requests/Recruitment/JobRequest.php
@@ -16,6 +16,7 @@ class JobRequest extends FormRequest
         if ($this->method() === 'POST') {
             $rules = [
                 'title' => 'required|string',
+                'domain' => 'required|string',
                 'description' => 'required|string',
                 'type' => 'required|string|in:job,internship,volunteer',
                 'status' => 'required|string',
@@ -27,6 +28,7 @@ class JobRequest extends FormRequest
         if ($this->method() === 'PATCH') {
             $rules = [
                 'title' => 'required|string',
+                'domain' => 'required|string',
                 'description' => 'required|string',
                 'type' => 'required|string|in:job,internship,volunteer',
                 'status' => 'required|string',

--- a/database/migrations/2021_07_16_182228_add_domain_to_hr_jobs.php
+++ b/database/migrations/2021_07_16_182228_add_domain_to_hr_jobs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDomainToHrJobs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_jobs', function (Blueprint $table) {
+            $table->string('domain')->after('type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_jobs', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_07_16_182228_add_domain_to_hr_jobs.php
+++ b/database/migrations/2021_07_16_182228_add_domain_to_hr_jobs.php
@@ -26,7 +26,7 @@ class AddDomainToHrJobs extends Migration
     public function down()
     {
         Schema::table('hr_jobs', function (Blueprint $table) {
-            //
+            $table->dropColumn('domain');
         });
     }
 }

--- a/resources/views/hr/job/create.blade.php
+++ b/resources/views/hr/job/create.blade.php
@@ -43,7 +43,7 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<label class="text-danger">*</label></label>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<strong class="text-danger">*</strong></label>
                         <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
                             @foreach (config('hr.opportunities.domains') as $domain => $label)
                                 <option value="{{ $domain }}" {{ old('domain') == $domain ? 'selected' : '' }}>{{ $label }}</option>

--- a/resources/views/hr/job/create.blade.php
+++ b/resources/views/hr/job/create.blade.php
@@ -42,6 +42,14 @@
                             <option value="internship" {{ old('type') == 'internship' ? 'selected' : '' }}>Internship</option>
                         </select>
                     </div>
+                    <div class="col-md-3 form-group">
+                     <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}">
+                            @foreach (config('hr.domain-status') as $domain => $label)
+                            <option value="{{ $domain }}" {{ old('domain') == $domain ? 'selected' : '' }}>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="description" class="fz-14 leading-none text-secondary mb-1">Description</label>

--- a/resources/views/hr/job/create.blade.php
+++ b/resources/views/hr/job/create.blade.php
@@ -43,10 +43,10 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                     <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
-                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}">
-                            @foreach (config('hr.domain-status') as $domain => $label)
-                            <option value="{{ $domain }}" {{ old('domain') == $domain ? 'selected' : '' }}>{{ $label }}</option>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
+                            @foreach (config('hr.opportunities.domains') as $domain => $label)
+                                <option value="{{ $domain }}" {{ old('domain') == $domain ? 'selected' : '' }}>{{ $label }}</option>
                             @endforeach
                         </select>
                     </div>

--- a/resources/views/hr/job/create.blade.php
+++ b/resources/views/hr/job/create.blade.php
@@ -43,7 +43,7 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<label class="text-danger">*</label></label>
                         <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
                             @foreach (config('hr.opportunities.domains') as $domain => $label)
                                 <option value="{{ $domain }}" {{ old('domain') == $domain ? 'selected' : '' }}>{{ $label }}</option>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -50,7 +50,7 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<label class="text-danger">*</label></label>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<strong class="text-danger">*</strong></label>
                         <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
                             @foreach (config('hr.opportunities.domains') as $domain => $label)
                                 <option value="{{ $domain }}" {{ old('domain', $job->domain) == $domain ? 'selected' : '' }}>{{ $label }}</option>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -50,7 +50,7 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain<label class="text-danger">*</label></label>
                         <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
                             @foreach (config('hr.opportunities.domains') as $domain => $label)
                                 <option value="{{ $domain }}" {{ old('domain', $job->domain) == $domain ? 'selected' : '' }}>{{ $label }}</option>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -50,10 +50,10 @@
                         </select>
                     </div>
                     <div class="col-md-3 form-group">
-                     <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
-                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}">
-                            @foreach (config('hr.domain-status') as $domain => $label)
-                            <option value="{{ $domain }}" {{ old('domain', $job->domain) == $domain ? 'selected' : '' }}>{{ $label }}</option>
+                        <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}" required>
+                            @foreach (config('hr.opportunities.domains') as $domain => $label)
+                                <option value="{{ $domain }}" {{ old('domain', $job->domain) == $domain ? 'selected' : '' }}>{{ $label }}</option>
                             @endforeach
                         </select>
                     </div>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -49,6 +49,14 @@
                             <option value="internship" {{ old('type', $job->type) == 'internship' ? 'selected' : '' }}>Internship</option>
                         </select>
                     </div>
+                    <div class="col-md-3 form-group">
+                     <label for="domain" class="fz-14 leading-none text-secondary mb-1">Domain</label>
+                        <select class="form-control" name="domain" id="domain" value="{{ old('domain') }}">
+                            @foreach (config('hr.domain-status') as $domain => $label)
+                            <option value="{{ $domain }}" {{ old('domain', $job->domain) == $domain ? 'selected' : '' }}>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="description" class="fz-14 leading-none text-secondary mb-1">Job Description</label>


### PR DESCRIPTION
Issue linked #173 
## Summary
1. Created `domain-status` variable in `Modules/HR/Config/config.php` which stores Engineering, Design, Marketing.
2. Updated `$fillable` in `Modules/HR/Entities/Job.php` for domain field.
3.  Updated `Modules/HR/Http/Controllers/Recruitment/JobController.php` to validate `domain`.
4. Updated validate `rule` for `domain` in `Modules/HR/Http/Requests/Recruitment/JobRequest.php`.
5. Created `database/migrations/2021_07_16_182228_add_domain_to_hr_jobs.php` for migrating `domain` column to `hr_jobs` table.
6. Updated  `resources/views/hr/job/create.blade.php` and `resources/views/hr/job/edit.blade.php` for showing `domain` as a field.